### PR TITLE
OryaHub/project-management#134[fix: libs/components, libs/interfaces]…

### DIFF
--- a/libs/adapters/manager_adapter_utils.go
+++ b/libs/adapters/manager_adapter_utils.go
@@ -172,9 +172,13 @@ func (l *ManagerAdapter) getActionsFiles(configurations dto.StateCheckDatadogCon
 // parseSiteDatadog execute parse the site datadog
 func (l *ManagerAdapter) parseSiteDatadog(site string) string {
 	l.logger.Debug("parse site datadog", "trace", "agent-os-instance.manager_adapter.parseSiteDatadog", "site", site)
+	defaultSite := "datadoghq.com"
 	host, err := utils.GetBaseUrlSite(site)
 	if err != nil {
-		return "datadoghq.com"
+		return defaultSite
+	}
+	if len(host) == 0 {
+		return defaultSite
 	}
 	return host
 }

--- a/libs/components/datadog_linux_operations.go
+++ b/libs/components/datadog_linux_operations.go
@@ -138,8 +138,13 @@ func (d *DatadogLinuxOperation) UninstallAgent() error {
 // so credentials persist even when datadog.yaml is overwritten by cloud config
 func (d *DatadogLinuxOperation) WriteEnvironmentFile(ddSite, ddApiKey string) error {
 	d.logger.Debug("write environment file", "trace", "agent-os-instance.datadog_linux_operations.WriteEnvironmentFile")
+	datadogPath, err := d.DiscoverDatadogConfigPath()
+	if err != nil {
+		return err
+	}
+	envFilePath := filepath.Join(datadogPath, "environment")
 	content := fmt.Sprintf("DD_API_KEY=%s\nDD_SITE=%s\n", ddApiKey, ddSite)
-	if err := d.program.Execute("sudo", []string{}, "bash", "-c", fmt.Sprintf("echo '%s' | tee /etc/datadog-agent/environment > /dev/null", content)); err != nil {
+	if err := d.program.Execute("sudo", []string{}, "bash", "-c", fmt.Sprintf("echo '%s' | tee %s > /dev/null", content, envFilePath)); err != nil {
 		return err
 	}
 	return nil

--- a/libs/components/datadog_linux_operations.go
+++ b/libs/components/datadog_linux_operations.go
@@ -68,6 +68,9 @@ func (d *DatadogLinuxOperation) InstallAgent(ddSite, ddApiKey, version string) e
 		if err := d.program.Execute("bash", envs, "-c", fmt.Sprintf("export DD_API_KEY=%s;export DD_SITE=%s;%s", ddApiKey, ddSite, CURL_INSTALL_SH)); err != nil {
 			return err
 		}
+		if err := d.WriteEnvironmentFile(ddSite, ddApiKey); err != nil {
+			return err
+		}
 	} else {
 		d.logger.Debug("install agent", "trace", "agent-os-instance.datadog_linux_operations.InstallAgent", "aptOrDpkgIsRunning", aptOrDpkgIsRunning)
 	}
@@ -86,6 +89,9 @@ func (d *DatadogLinuxOperation) InstallAgentApmSingleStep(ddSite string, ddApiKe
 	if !aptOrDpkgIsRunning {
 		d.logger.Debug("install agent apm single step", "trace", "agent-os-instance.datadog_linux_operations.InstallAgentApmSingleStep", "aptOrDpkgIsRunning", aptOrDpkgIsRunning)
 		if err := d.program.Execute("bash", envs, "-c", fmt.Sprintf("export DD_API_KEY=%s;export DD_SITE=%s;export DD_APM_INSTRUMENTATION_ENABLED=%s;export DD_APM_INSTRUMENTATION_LIBRARIES=%s;%s", ddApiKey, ddSite, ddApmInstrumentationEnabled, ddApmInstrumentationLibraries, CURL_INSTALL_SH)); err != nil {
+			return err
+		}
+		if err := d.WriteEnvironmentFile(ddSite, ddApiKey); err != nil {
 			return err
 		}
 	} else {
@@ -125,6 +131,17 @@ func (d *DatadogLinuxOperation) UninstallAgent() error {
 		d.logger.Debug("uninstall agent", "trace", "agent-os-instance.datadog_linux_operations.UninstallAgent", "aptOrDpkgIsRunning", aptOrDpkgIsRunning)
 	}
 
+	return nil
+}
+
+// WriteEnvironmentFile write DD_API_KEY and DD_SITE to /etc/datadog-agent/environment
+// so credentials persist even when datadog.yaml is overwritten by cloud config
+func (d *DatadogLinuxOperation) WriteEnvironmentFile(ddSite, ddApiKey string) error {
+	d.logger.Debug("write environment file", "trace", "agent-os-instance.datadog_linux_operations.WriteEnvironmentFile")
+	content := fmt.Sprintf("DD_API_KEY=%s\nDD_SITE=%s\n", ddApiKey, ddSite)
+	if err := d.program.Execute("sudo", []string{}, "bash", "-c", fmt.Sprintf("echo '%s' | tee /etc/datadog-agent/environment > /dev/null", content)); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/libs/components/datadog_windows_operation_stub.go
+++ b/libs/components/datadog_windows_operation_stub.go
@@ -96,3 +96,8 @@ func (d *DatadogWindowsOperation) DPKGConfigure() error {
 func (d *DatadogWindowsOperation) GetInfos() ([]byte, error) {
 	return nil, nil
 }
+
+// WriteEnvironmentFile write DD_API_KEY and DD_SITE to environment file
+func (d *DatadogWindowsOperation) WriteEnvironmentFile(ddSite, ddApiKey string) error {
+	return nil
+}

--- a/libs/components/datadog_windows_operations.go
+++ b/libs/components/datadog_windows_operations.go
@@ -82,6 +82,9 @@ func (d *DatadogWindowsOperation) InstallAgent(ddSite, ddApiKey, version string)
 				return err
 			}
 			d.logger.Debug("install agent datadog", "output", out)
+			if err := d.WriteEnvironmentFile(ddSite, ddApiKey); err != nil {
+				return err
+			}
 			return nil
 		}
 		return err
@@ -116,6 +119,9 @@ func (d *DatadogWindowsOperation) InstallAgentApmSingleStep(ddSite string, ddApi
 				return err
 			}
 			d.logger.Debug("install agent datadog with apm single step", "output", out)
+			if err := d.WriteEnvironmentFile(ddSite, ddApiKey); err != nil {
+				return err
+			}
 			return nil
 		}
 		return err
@@ -396,4 +402,21 @@ func (d *DatadogWindowsOperation) GetInfos() ([]byte, error) {
 
 	data, err := d.json.Marshall(datadogInfos)
 	return data, err
+}
+
+// WriteEnvironmentFile write DD_API_KEY and DD_SITE to C:\ProgramData\Datadog\environment
+// so credentials persist even when datadog.yaml is overwritten by cloud config
+func (d *DatadogWindowsOperation) WriteEnvironmentFile(ddSite, ddApiKey string) error {
+	d.logger.Debug("write environment file", "trace", "agent-os-instance.datadog_windows_operations.WriteEnvironmentFile")
+	datadogPath, err := d.DiscoverDatadogConfigPath()
+	if err != nil {
+		return err
+	}
+	envFilePath := filepath.Join(datadogPath, "environment")
+	content := fmt.Sprintf("DD_API_KEY=%s\nDD_SITE=%s\n", ddApiKey, ddSite)
+	command := fmt.Sprintf(`Set-Content -Path '%s' -Value '%s' -Force`, envFilePath, content)
+	if _, err := d.program.ExecuteWithOutput("powershell", []string{}, "-NoProfile", "-Command", command); err != nil {
+		return err
+	}
+	return nil
 }

--- a/libs/components/datadog_windows_operations.go
+++ b/libs/components/datadog_windows_operations.go
@@ -378,7 +378,7 @@ func (d *DatadogWindowsOperation) DPKGConfigure() error {
 
 // GetInfos fetch datadog infos
 func (d *DatadogWindowsOperation) GetInfos() ([]byte, error) {
-	output, err := d.program.ExecuteWithOutput("powershell", []string{},"-NoProfile","-Command",`& "$env:ProgramFiles\\Datadog\\Datadog Agent\\bin\\agent.exe"`, "status")
+	output, err := d.program.ExecuteWithOutput("powershell", []string{}, "-NoProfile", "-Command", `& "$env:ProgramFiles\\Datadog\\Datadog Agent\\bin\\agent.exe"`, "status")
 	if err != nil {
 		return nil, err
 	}
@@ -413,6 +413,11 @@ func (d *DatadogWindowsOperation) WriteEnvironmentFile(ddSite, ddApiKey string) 
 		return err
 	}
 	envFilePath := filepath.Join(datadogPath, "environment")
+	if err := d.fileSystem.VerifyFileExist(envFilePath); err != nil {
+		if errCrt := d.fileSystem.CreateFile(envFilePath); errCrt != nil {
+			return errCrt
+		}
+	}
 	content := fmt.Sprintf("DD_API_KEY=%s\nDD_SITE=%s\n", ddApiKey, ddSite)
 	command := fmt.Sprintf(`Set-Content -Path '%s' -Value '%s' -Force`, envFilePath, content)
 	if _, err := d.program.ExecuteWithOutput("powershell", []string{}, "-NoProfile", "-Command", command); err != nil {

--- a/libs/interfaces/datadog_interface.go
+++ b/libs/interfaces/datadog_interface.go
@@ -18,4 +18,5 @@ type IDatadogOperation interface {
 	RollbackVersion(version string) error
 	DPKGConfigure() error
 	GetInfos() ([]byte, error)
+	WriteEnvironmentFile(ddSite, ddApiKey string) error
 }

--- a/libs/utils/transforms.go
+++ b/libs/utils/transforms.go
@@ -27,17 +27,15 @@ func TransformMapToSlice(mapp map[string]interface{}) ([]string, error) {
 
 // GetBaseUrlSite return base url from site
 func GetBaseUrlSite(site string) (string, error) {
+	if !strings.HasPrefix(site, "http://") && !strings.HasPrefix(site, "https://") {
+		site = "https://" + site
+	}
 	u, err := url.Parse(site)
 	if err != nil {
 		return "", err
 	}
 
-	host := u.Host
-
-	parts := strings.Split(host, ".")
-	if len(parts) >= 2 {
-		host = strings.Join(parts[len(parts)-2:], ".")
-	}
+	host := u.Hostname()
 	return host, nil
 }
 


### PR DESCRIPTION
## Implementação inicial  e descrição do Claude Opus 4.6

[fix: libs/components, libs/interfaces]: persist DD_API_KEY and DD_SITE to environment file after Datadog install

Cloud config updates overwrite datadog.yaml, wiping the api_key written by the install script.

Writing DD_API_KEY and DD_SITE to /environment ensures credentials persist across

datadog.yaml replacements, as env vars take precedence over config file values (supported since Agent 7.45).

- Add WriteEnvironmentFile to IDatadogOperation interface
- Linux: write to /etc/datadog-agent/environment after install
- Windows: write to C:\ProgramData\Datadog\environment after install
- Called in both InstallAgent and InstallAgentApmSingleStep paths